### PR TITLE
Bump and publish workflows

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -1,0 +1,22 @@
+name: Bump Version
+
+on:
+  push:
+    branches:
+      - "main"
+  workflow_dispatch:
+
+jobs:
+  bump-version:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+
+      - name: "Automated version bump"
+        uses: "phips28/gh-action-bump-version@master"
+        with:
+          tag-prefix: "v"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,30 @@
+name: Publish
+
+on:
+  push:
+    branches:
+      - "main"
+
+jobs:
+  npm-publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+
+      - name: Setup node
+        uses: actions/setup-node@v1
+        with:
+          node-version: 16.x
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Build
+        run: yarn run build
+
+      - name: Publish to NPM
+        uses: JS-DevTools/npm-publish@v1
+        with:
+          token: ${{ secrets.NPM_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ import { loadCatchjs } from "@get-catch/catchjs";
 const catchjs = await loadCatchjs();
 ```
 
-Catch.js may be loaded in either "sandbox" mode (intended for dev/test environments) or "live" mode(for production). By default, `loadCatchjs()` will load the sandbox mode. For live mode, pass an `options` argument to `loadCatchjs()` with the entry `live: true`:
+Catch.js may be loaded in either "sandbox" mode (intended for dev/test environments) or "live" mode (for production). By default, `loadCatchjs()` will load the sandbox mode. For live mode, pass an `options` argument to `loadCatchjs()` with the entry `live: true`:
 
 ```js
 const catchjs = await loadCatchjs({


### PR DESCRIPTION
### Summary

First pass on two discrete Github actions workflows, one to automatically bump the version in `package.json` and create a tag for that version in the repo, and one to publish a new version to NPM.

Both of these workflows are triggered by pushing to the `main` branch.
- The bump workflow looks at the commit message to determine whether to increment the patch vs. minor vs. major part of the version. By default, the patch is incremented, but keywords in the commit message such as "feat" or "BREAKING CHANGE" can be used to target a minor/major version. See [these docs](https://github.com/phips28/gh-action-bump-version#workflow) for details.
- The publish workflow only actually publishes to NPM if the package version has changed and is ahead of whatever's already been put up on NPM.

Because both workflows are triggered by pushing to `main`, I'm expecting here that the publish workflow will technically run twice, but the first run should essentially be a no op.
Essentially, this is what the overall flow should be:

1. A PR is approved and merged into `main`.
2. The bump workflow and the publish workflow are simultaneously kicked off.
3. The publish workflow doesn't do anything because the package version hasn't changed.
4. The bump workflow increments the version and commits that change back to `main`.
5. The bump and publish workflows are kicked off again.
6. This time, the bump workflow is a no op because it recognizes that the commit is its own version bump.
7. This time, the publish workflow actually publishes to NPM because now the package version is different.

### References
For reference, I'm using these main actions:
- [Automated Version Bump](https://github.com/marketplace/actions/automated-version-bump)
- [NPM Publish](https://github.com/marketplace/actions/npm-publish)