### PR TITLE
Run publish workflow on push tag

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,8 +2,8 @@ name: Publish
 
 on:
   push:
-    branches:
-      - "main"
+    tags:
+      - "*"
 
 jobs:
   npm-publish:


### PR DESCRIPTION
### Summary

Instead of running the publish workflow on all pushes to `main`, run it when a new tag is created (which is done right now by the "bump" workflow).