### PR TITLE
Set access to public when publishing to NPM

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,3 +30,4 @@ jobs:
         uses: JS-DevTools/npm-publish@v1
         with:
           token: ${{ secrets.NPM_TOKEN }}
+          access: "public"


### PR DESCRIPTION
### Summary
It looks like, because this is a scoped package, the NPM publish action is using restricted access by default ([see docs](https://github.com/marketplace/actions/npm-publish#input-parameters)), which is failing. This sets the access to "public".