### PR TITLE
Remove postinstall hook for husky

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
   "typings": "types/index.d.ts",
   "version": "1.0.7",
   "scripts": {
-    "postinstall": "husky install",
     "dev": "vite",
     "build": "tsc && vite build",
     "lint": "eslint src/ --ext .ts,.tsx",


### PR DESCRIPTION
### Summary
We don't want to run `husky install` when users are installing the package from NPM.