### PR TITLE
Basic TypeScript support

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,7 @@ const catchjs = await loadCatchjs({
 `loadCatchjs()` returns a `Promise` that resolves with the `catchjs` namespace object once Catch.js has loaded, and rejects if Catch.js fails to load. This function should only be invoked in a browser or browser-like environment (i.e. when `window` is defined), and will reject if invoked in a server environment.
 
 Once loaded, Catch.js must still be initialized by calling `catchjs.init()` (refer to the [initialization docs](https://catch.readme.io/reference/catchjs#initialization)).
+
+## TypeScript Support
+
+This package ships with TypeScript declarations for the loading utility, as well as the Catch.js SDK itself.

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -51,6 +51,10 @@ interface CatchWindow extends Window {
   catchjs?: CatchSDK;
 }
 
+declare module "@get-catch/catchjs" {
+  const loadCatchjs: (options: CatchLoadOptions) => Promise<CatchSDK>;
+}
+
 export type {
   Theme,
   PageType,


### PR DESCRIPTION
### Summary
- Ensure `loadCatchjs()` can be used in TypeScript projects by including a module declaration in the type declarations.
- Note TypeScript support in the README.