### PR TITLE
Add type declarations for themes

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -28,6 +28,7 @@ const initStartTime = performance.now();
 // Initialize with test public key for Merch by Catch.
 await catchjs.init("Ei6eCMabeqZT3AuiFcX3XuUC", {
   pageType: "demo",
+  theme: "dark-mono",
 });
 const initEndTime = performance.now();
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,4 +1,4 @@
-type Theme = "default";
+type Theme = "light-color" | "light-mono" | "dark-color" | "dark-mono";
 
 type PageType =
   | "unknown"
@@ -28,6 +28,7 @@ interface CatchOptions {
 }
 
 interface CatchHandle {
+  setTheme: (theme: Theme) => void;
   setPageType: (pageType: PageType) => void;
   openCheckout: (checkoutId: string, options?: OpenCheckoutOptions) => void;
 }


### PR DESCRIPTION
### Summary
This should go in after we deploy our updates for theme support in the SDK (which I have a PR up for). This is just adding new type declarations for the new theme stuff. In the local dev environment demo, the SDK is also now initialized with a non-default theme ("dark-mono").