### PR TITLE
Fix lint-staged config to scope eslint to only staged files

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
   },
   "lint-staged": {
     "src/**/*.{js,jsx,ts,tsx,css}": [
-      "yarn lint",
+      "eslint",
       "prettier --write"
     ]
   },


### PR DESCRIPTION
Fix `lint-staged` setup by calling the raw `eslint` command directly, rather than our `lint` custom script. This ensures that `eslint` correctly receives the staged files that `lint-staged` passes along as arguments, so that only staged files are linted on pre-commit. `yarn lint` script will currently scope the linting to the entire `src/` directory.