### PR TITLE
Adding hideHeader option to OpenCheckoutOptions interface

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -21,6 +21,7 @@ interface OpenCheckoutOptions {
   onConfirm?: () => void;
   prefill?: CheckoutPrefill;
   autoCloseOnConfirm?: boolean;
+  hideHeader?: boolean;
 }
 
 interface CatchOptions {


### PR DESCRIPTION
### Summary

Providing the ability to remove the header from the cart in checkout. To hide the header, call `openCheckout()` with an `hideHeader` set to true in the `options` parameter.