### PR TITLE
Allow non-production environment loading

### DIFF
--- a/src/loading.test.ts
+++ b/src/loading.test.ts
@@ -1,6 +1,5 @@
 import {
-  SANDBOX_SCRIPT_URL,
-  LIVE_SCRIPT_URL,
+  getScriptUrl,
   loadCatchjs,
   getNamespace,
   resetForTests,
@@ -19,8 +18,10 @@ const injectScript = (scriptUrl: string): Promise<void> => {
   });
 };
 
-const preloadSandbox = (): Promise<void> => injectScript(SANDBOX_SCRIPT_URL);
-const preloadLive = (): Promise<void> => injectScript(LIVE_SCRIPT_URL);
+const preloadSandbox = (): Promise<void> =>
+  injectScript(getScriptUrl("production", false));
+const preloadLive = (): Promise<void> =>
+  injectScript(getScriptUrl("production", true));
 
 interface ShimmedWindowForTests extends Window {
   require: () => unknown;

--- a/src/loading.ts
+++ b/src/loading.ts
@@ -1,8 +1,21 @@
-import type { CatchSDK, CatchLoadOptions, CatchWindow } from "../types";
+import type {
+  CatchSDK,
+  CatchLoadOptions,
+  CatchWindow,
+  CatchEnvironment,
+} from "../types";
 
-const SANDBOX_SCRIPT_URL =
-  "https://js-sandbox.getcatch.com/catchjs/v1/catch.js";
-const LIVE_SCRIPT_URL = "https://js.getcatch.com/catchjs/v1/catch.js";
+const getScriptUrl = (environment: CatchEnvironment, live: boolean): string => {
+  let envDomainPart = "";
+  if (environment === "staging") {
+    envDomainPart = "staging.";
+  } else if (environment === "development") {
+    envDomainPart = "dev.";
+  }
+  return `https://${envDomainPart}js${
+    live ? "" : "-sandbox"
+  }.getcatch.com/catchjs/v1/catch.js`;
+};
 
 let catchPromise: Promise<CatchSDK> | null = null;
 
@@ -40,7 +53,13 @@ const loadCatchjs = (options: CatchLoadOptions = {}): Promise<CatchSDK> => {
       return;
     }
 
-    const { live = false } = options;
+    const { live = false, environment = "production" } = options;
+
+    if (environment !== "production") {
+      console.warn(
+        `Load Catch.js: A non-production version of Catch.js is being requested. The ${environment} build of Catch.js is intended only for internal/experimental use and provides no guarantee of stability. Proceed with caution.`
+      );
+    }
 
     let catchjs = getNamespace();
     if (catchjs) {
@@ -63,7 +82,7 @@ const loadCatchjs = (options: CatchLoadOptions = {}): Promise<CatchSDK> => {
       return;
     }
 
-    const scriptUrl = live ? LIVE_SCRIPT_URL : SANDBOX_SCRIPT_URL;
+    const scriptUrl = getScriptUrl(environment, live);
     let inject = false;
     let script = document.querySelector<HTMLScriptElement>(
       `script[src="${scriptUrl}"]`
@@ -115,10 +134,4 @@ const resetForTests = (): void => {
   catchPromise = null;
 };
 
-export {
-  SANDBOX_SCRIPT_URL,
-  LIVE_SCRIPT_URL,
-  loadCatchjs,
-  getNamespace,
-  resetForTests,
-};
+export { getScriptUrl, loadCatchjs, getNamespace, resetForTests };

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -48,8 +48,11 @@ interface CatchSDK {
   info: SDKInfo;
 }
 
+type CatchEnvironment = "development" | "staging" | "production";
+
 interface CatchLoadOptions {
   live?: boolean;
+  environment?: CatchEnvironment;
 }
 
 interface CatchWindow extends Window {
@@ -71,4 +74,5 @@ export type {
   CatchSDK,
   CatchLoadOptions,
   CatchWindow,
+  CatchEnvironment,
 };


### PR DESCRIPTION
### Overview

Allow for internal, non-production builds of Catch.js to be loaded via `loadCatchjs()`. This feature is intended strictly for internal/experimental usage. As such, the `environment` option defaults to production, isn't documented (for now), and the unit tests remain against the "production" environment. If "staging" or "development" is passed as the environment, log a moderately loud warning about this in the console.