### PR TITLE
Update type declaration to make loadCatchjs options explicitly optional

### DIFF
--- a/src/loading.ts
+++ b/src/loading.ts
@@ -38,7 +38,7 @@ let catchPromise: Promise<CatchSDK> | null = null;
  *
  * Once loaded, the SDK must still be initialized by calling `catchjs.init()`.
  */
-const loadCatchjs = (options: CatchLoadOptions = {}): Promise<CatchSDK> => {
+const loadCatchjs = (options?: CatchLoadOptions): Promise<CatchSDK> => {
   // `loadCatchjs()` should only be called once in the lifecycle of an application.
   // However, in case it's called more than once, always return the result of the
   // original call.
@@ -53,7 +53,7 @@ const loadCatchjs = (options: CatchLoadOptions = {}): Promise<CatchSDK> => {
       return;
     }
 
-    const { live = false, environment = "production" } = options;
+    const { live = false, environment = "production" } = options || {};
 
     if (environment !== "production") {
       console.warn(

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -60,7 +60,7 @@ interface CatchWindow extends Window {
 }
 
 declare module "@get-catch/catchjs" {
-  const loadCatchjs: (options: CatchLoadOptions) => Promise<CatchSDK>;
+  const loadCatchjs: (options?: CatchLoadOptions) => Promise<CatchSDK>;
 }
 
 export type {


### PR DESCRIPTION
## Overview

Fix bug in type declaration for `loadCatchjs` where the `options` argument wasn't actually optional (it should be).
For further clarity (and to keep the function signature the same), I also updated the implementation to define the argument as optional, without relying on a default initializer.