### PR TITLE
Cut a new minor version with updated virtual card types.

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,4 +1,4 @@
-import { CardDetails, CreateVCNCheckoutPayload } from "./vcn";
+import { CardDetails, CreateVirtualCardCheckoutPayload } from "./vcn";
 
 type Theme = "light-color" | "light-mono" | "dark-color" | "dark-mono";
 
@@ -41,8 +41,7 @@ interface CatchHandle {
   trackPaymentMethodSelected: () => void;
   openCheckout: (checkoutId: string, options?: OpenCheckoutOptions) => void;
   createAndOpenVirtualCardCheckout: (
-    orderId: string,
-    createVCNCheckoutPayload: CreateVCNCheckoutPayload,
+    createVirtualCardCheckoutPayload: CreateVirtualCardCheckoutPayload,
     options?: VirtualCardCheckoutOptions
   ) => void;
   closeConfirmedCheckout: () => void;
@@ -82,7 +81,7 @@ export type {
   VirtualCardCheckoutOptions,
   CatchOptions,
   CatchHandle,
-  CreateVCNCheckoutPayload,
+  CreateVirtualCardCheckoutPayload,
   SDKInfo,
   CatchSDK,
   CatchLoadOptions,

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -40,6 +40,10 @@ interface CatchHandle {
   setPageType: (pageType: PageType) => void;
   trackPaymentMethodSelected: () => void;
   openCheckout: (checkoutId: string, options?: OpenCheckoutOptions) => void;
+  openVirtualCardCheckout: (
+    checkoutId: string,
+    options?: VirtualCardCheckoutOptions
+  ) => void;
   createAndOpenVirtualCardCheckout: (
     createVirtualCardCheckoutPayload: CreateVirtualCardCheckoutPayload,
     options?: VirtualCardCheckoutOptions

--- a/types/vcn.d.ts
+++ b/types/vcn.d.ts
@@ -31,14 +31,18 @@ interface Shipping {
   phone_number?: string;
 }
 
+interface Price {
+  amount: number;
+  currency: string;
+}
+
 interface Item {
   name: string;
   sku: string;
-  price: number;
+  price: Price;
   quantity: number;
-  category?: string[];
+  category?: Array<string>;
   image_url: string;
-  currency: string;
 }
 
 type Items = Array<Item>;
@@ -48,8 +52,8 @@ interface Platform {
   platform_version?: string;
 }
 
-interface CreateVCNCheckoutPayload {
-  merchant_public_key: string;
+interface CreateVirtualCardCheckoutPayload {
+  merchant_order_id: string;
   merchant_user_id: string;
   amounts: Amounts;
   billing: Billing;
@@ -68,7 +72,4 @@ interface CardDetails {
   zip_code: string;
 }
 
-export type {
-  CardDetails,
-  CreateVCNCheckoutPayload,
-}
+export type { CardDetails, CreateVirtualCardCheckoutPayload };


### PR DESCRIPTION
Updates virtual card types:
- Adds `openVirtualCardCheckout` to `CatchHandle`
- Removes `orderId` from `createAndOpenVirtualCardCheckout` arguments
- Adds `merchant_order_id` to `CreateVirtualCardCheckoutPayload`
- Updates `Price` property of `Item`